### PR TITLE
Fixes menu stacking issue 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
 				"core-js": "^3.31.1",
 				"fast-deep-equal": "^3.1.3",
 				"json-schema-merge-allof": "^0.8.1",
-				"patch-package": "^7.0.2"
+				"patch-package": "^7.0.2",
+				"svelte-portal": "^2.2.0"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",
@@ -3134,6 +3135,11 @@
 				"svelte": ">=3.19.0"
 			}
 		},
+		"node_modules/svelte-portal": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
+			"integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg=="
+		},
 		"node_modules/svelte-preprocess": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.3.tgz",
@@ -5926,6 +5932,11 @@
 			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
 			"dev": true,
 			"requires": {}
+		},
+		"svelte-portal": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
+			"integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg=="
 		},
 		"svelte-preprocess": {
 			"version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"core-js": "^3.31.1",
 		"fast-deep-equal": "^3.1.3",
 		"json-schema-merge-allof": "^0.8.1",
-		"patch-package": "^7.0.2"
+		"patch-package": "^7.0.2",
+		"svelte-portal": "^2.2.0"
 	}
 }

--- a/patches/@smui+select+7.0.0-beta.14.patch
+++ b/patches/@smui+select+7.0.0-beta.14.patch
@@ -1,12 +1,12 @@
 diff --git a/node_modules/@smui/select/dist/Select.svelte b/node_modules/@smui/select/dist/Select.svelte
-index f56ba6e..280a571 100644
+index f56ba6e..b1ffcbe 100644
 --- a/node_modules/@smui/select/dist/Select.svelte
 +++ b/node_modules/@smui/select/dist/Select.svelte
 @@ -172,13 +172,15 @@
      {/if}
    </div>
  
-+  <Portal disable={!menu$portal}>
++  <Portal class="smui-select__menu-portal" disable={!menu$portal}>
    <Menu
 +    bind:this={menu}
      class={classMap({
@@ -31,7 +31,7 @@ index f56ba6e..280a571 100644
  import LineRipple from '@smui/line-ripple';
  import NotchedOutline from '@smui/notched-outline';
  import HelperText from './helper-text/HelperText.svelte';
-+import Portal, {portal} from 'svelte-portal';
++import Portal from 'svelte-portal';
  const forwardEvents = forwardEventsBuilder(get_current_component());
  let uninitializedValue = () => { };
  function isUninitializedValue(value) {

--- a/patches/@smui+select+7.0.0-beta.14.patch
+++ b/patches/@smui+select+7.0.0-beta.14.patch
@@ -1,0 +1,75 @@
+diff --git a/node_modules/@smui/select/dist/Select.svelte b/node_modules/@smui/select/dist/Select.svelte
+index f56ba6e..280a571 100644
+--- a/node_modules/@smui/select/dist/Select.svelte
++++ b/node_modules/@smui/select/dist/Select.svelte
+@@ -172,13 +172,15 @@
+     {/if}
+   </div>
+ 
++  <Portal disable={!menu$portal}>
+   <Menu
++    bind:this={menu}
+     class={classMap({
+       [menu$class]: true,
+       'mdc-select__menu': true,
+       ...menuClasses,
+     })}
+-    fullWidth
++    fullWidth={!menu$portal}
+     anchor={false}
+     {anchorElement}
+     {anchorCorner}
+@@ -198,6 +200,7 @@
+       {...prefixFilter($$restProps, 'list$')}><slot /></List
+     >
+   </Menu>
++  </Portal>
+ </div>
+ {#if $$slots.helperText}
+   <HelperText
+@@ -230,6 +233,7 @@ import FloatingLabel from '@smui/floating-label';
+ import LineRipple from '@smui/line-ripple';
+ import NotchedOutline from '@smui/notched-outline';
+ import HelperText from './helper-text/HelperText.svelte';
++import Portal, {portal} from 'svelte-portal';
+ const forwardEvents = forwardEventsBuilder(get_current_component());
+ let uninitializedValue = () => { };
+ function isUninitializedValue(value) {
+@@ -269,6 +273,7 @@ export let selectedText$class = '';
+ export let dropdownIcon$use = [];
+ export let dropdownIcon$class = '';
+ export let menu$class = '';
++export let menu$portal = false;
+ let element;
+ let instance;
+ let internalClasses = {};
+@@ -279,6 +284,7 @@ let selectedIndex = -1;
+ let helperId = undefined;
+ let addLayoutListener = getContext('SMUI:addLayoutListener');
+ let removeLayoutListener;
++let menu;
+ let menuOpen = false;
+ let menuClasses = {};
+ let anchorElement = undefined;
+@@ -337,6 +343,9 @@ if (addLayoutListener) {
+     removeLayoutListener = addLayoutListener(layout);
+ }
+ onMount(() => {
++    if (menu$portal) {
++      menu.getMenuSurface().setIsHoisted(true);
++    }
+     instance = new MDCSelectFoundation({
+         // getSelectAdapterMethods
+         // getMenuItemAttr: (menuItem: Element, attr: string) =>
+diff --git a/node_modules/@smui/select/src/Select.svelte b/node_modules/@smui/select/src/Select.svelte
+index 5c99bde..28f68b5 100644
+--- a/node_modules/@smui/select/src/Select.svelte
++++ b/node_modules/@smui/select/src/Select.svelte
+@@ -281,6 +281,7 @@
+     dropdownIcon$use?: ActionArray;
+     dropdownIcon$class?: string;
+     menu$class?: string;
++    menu$portal?: boolean;
+   };
+   type $$Props = OwnProps &
+     SmuiAttrs<'div', keyof OwnProps> & {

--- a/patches/svelte-portal+2.2.0.patch
+++ b/patches/svelte-portal+2.2.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/svelte-portal/src/Portal.svelte b/node_modules/svelte-portal/src/Portal.svelte
-index 510a1a5..d065135 100644
+index 510a1a5..11f020c 100644
 --- a/node_modules/svelte-portal/src/Portal.svelte
 +++ b/node_modules/svelte-portal/src/Portal.svelte
 @@ -55,8 +55,13 @@
@@ -14,7 +14,7 @@ index 510a1a5..d065135 100644
    <slot />
 -</div>
 +{:else}
-+  <div use:portal={target} hidden>
++  <div class={$$props.class} use:portal={target} hidden>
 +    <slot />
 +  </div>
 +{/if}

--- a/patches/svelte-portal+2.2.0.patch
+++ b/patches/svelte-portal+2.2.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/svelte-portal/src/Portal.svelte b/node_modules/svelte-portal/src/Portal.svelte
+index 510a1a5..d065135 100644
+--- a/node_modules/svelte-portal/src/Portal.svelte
++++ b/node_modules/svelte-portal/src/Portal.svelte
+@@ -55,8 +55,13 @@
+    * @type { HTMLElement|string}
+    */
+   export let target = "body";
++  export let disable = false;
+ </script>
+ 
+-<div use:portal={target} hidden>
++{#if disable}
+   <slot />
+-</div>
++{:else}
++  <div use:portal={target} hidden>
++    <slot />
++  </div>
++{/if}

--- a/src/lib/SchemaForm.svelte
+++ b/src/lib/SchemaForm.svelte
@@ -126,14 +126,21 @@
     margin: 12px 0;
   }
 
-  .jsonschema-form :global(.jsonschema-form-controls) {
+  .jsonschema-form :global(.jsonschema-form-controls),
+  .jsonschema-form :global(.control-anyof > .smui-paper__title) {
     display: flex;
     flex-wrap: wrap;
     gap: 24px;
   }
 
-  .jsonschema-form :global(.jsonschema-form-controls > .jsonschema-form-control) {
+  .jsonschema-form :global(.jsonschema-form-controls > .jsonschema-form-control),
+  .jsonschema-form :global(.jsonschema-form-controls .control-anyof-select) {
     flex-basis: 325px;
+  }
+
+  :global(.smui-select__menu-portal > .control-anyof-menu) {
+    width: 325px;
+    max-width: 80%;
   }
 
   .jsonschema-form :global(.jsonschema-form-controls > .control-array),

--- a/src/lib/SchemaForm.svelte
+++ b/src/lib/SchemaForm.svelte
@@ -138,7 +138,7 @@
     flex-basis: 325px;
   }
 
-  :global(.smui-select__menu-portal > .control-anyof-menu) {
+  :global(.smui-select__menu-portal > .mdc-select__menu) {
     width: 325px;
     max-width: 80%;
   }

--- a/src/lib/controls/AnyOfControl.svelte
+++ b/src/lib/controls/AnyOfControl.svelte
@@ -68,7 +68,14 @@
 
 <Paper variant="unelevated" class="jsonschema-form-control control-anyof">
   <Title>
-    <Select variant="outlined" key={getKey} bind:value={selected} menu$portal>
+    <Select 
+      variant="outlined"
+      key={getKey}
+      class="control-anyof-select"
+      menu$class="control-anyof-menu"
+      menu$portal
+      bind:value={selected}
+    >
       {#each schemas as schema, index (schema)}
         <Option value={schema}>{schema.title ?? `Option ${index + 1}` }</Option>
       {/each}

--- a/src/lib/controls/AnyOfControl.svelte
+++ b/src/lib/controls/AnyOfControl.svelte
@@ -68,7 +68,7 @@
 
 <Paper variant="unelevated" class="jsonschema-form-control control-anyof">
   <Title>
-    <Select variant="outlined" key={getKey} bind:value={selected}>
+    <Select variant="outlined" key={getKey} bind:value={selected} menu$portal>
       {#each schemas as schema, index (schema)}
         <Option value={schema}>{schema.title ?? `Option ${index + 1}` }</Option>
       {/each}

--- a/src/lib/controls/IntegerControl.svelte
+++ b/src/lib/controls/IntegerControl.svelte
@@ -37,7 +37,7 @@
 
 <div class="jsonschema-form-control control-integer">
   {#if enumValues?.length}
-    <Select variant="outlined" bind:value label={title} required={isRequired}>
+    <Select variant="outlined" bind:value label={title} required={isRequired} menu$portal>
       {#if !force}
         <Option value={null}/>
       {/if}

--- a/src/lib/controls/NumberControl.svelte
+++ b/src/lib/controls/NumberControl.svelte
@@ -37,7 +37,7 @@
 
 <div class="jsonschema-form-control control-number">
   {#if enumValues?.length}
-    <Select variant="outlined" bind:value label={title} required={isRequired}>
+    <Select variant="outlined" bind:value label={title} required={isRequired} menu$portal>
       {#if !force}
         <Option value={null}/>
       {/if}

--- a/src/lib/controls/StringControl.svelte
+++ b/src/lib/controls/StringControl.svelte
@@ -38,7 +38,7 @@
 
 <div class="jsonschema-form-control control-string">
   {#if enumValues?.length}
-    <Select  variant="outlined" bind:value label={title} required={isRequired}>
+    <Select  variant="outlined" bind:value label={title} required={isRequired} menu$portal>
       {#if !force}
         <Option value={null}/>
       {/if}


### PR DESCRIPTION
This patches the `@smui/select` library to put select menus into a [portal](https://github.com/romkor/svelte-portal), so will display over other elements. There were a lot of issues with setting menu's z-index due to the positioning and z-index of ancestor elements.

resolves #1