### PR TITLE
"ignoreEmpty" ui option

### DIFF
--- a/src/lib/Control.svelte
+++ b/src/lib/Control.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { JSONSchema7, JSONSchema7TypeName } from "json-schema";
+  import type UISchema from "./UISchema";
   import * as controls from "./controls";
 
   export let schema: JSONSchema7 | undefined;
   export let data: any = undefined;
+  export let uischema: UISchema = {};
   export let force: boolean = false;
 
   let control: any;
@@ -16,4 +18,4 @@
   }
 </script>
 
-<svelte:component this={control} {...schema} bind:data {force} />
+<svelte:component this={control} {...schema} bind:data {uischema} {force} />

--- a/src/lib/SchemaForm.svelte
+++ b/src/lib/SchemaForm.svelte
@@ -104,11 +104,11 @@
           <Subtitle>{dereferenced.description}</Subtitle>
         {/if}
         <Content class="jsonschema-form-controls">
-          <ObjectProps {...dereferenced} bind:data force />
+          <ObjectProps {...dereferenced} bind:data {uischema} force />
         </Content>
       </Paper>
     {:else}
-      <Control schema={dereferenced} bind:data force />
+      <Control schema={dereferenced} bind:data {uischema} force />
     {/if}
   {:catch error}
     <div class="error">ERROR: {error.message}</div>

--- a/src/lib/SchemaForm.svelte
+++ b/src/lib/SchemaForm.svelte
@@ -49,7 +49,7 @@
   $: updateUischemaStore(uischema);
 
   function updateUischemaStore(uischema: UISchema) {
-    $uischemaStore = uischema;
+    $uischemaStore = uischema[UISchema.Options.Key] ?? {};
   }
 
   export function validate() {

--- a/src/lib/UISchema.ts
+++ b/src/lib/UISchema.ts
@@ -4,32 +4,34 @@ import { writable, type Readable } from "svelte/store";
 import { hasRequired } from "./utilities";
 
 type UISchemaComponent<T extends string = string> =
-  (T extends typeof UISchema.OptionsKey ? never : { [key: string]: UISchemaComponent<T> }) &
-  {
-    [UISchema.OptionsKey]?: {
-      collapse?: UISchema.CollapseOption
-      ignoreEmpty?: boolean
-    }
-  };
+  (T extends typeof UISchema.Options.Key ? never : { [key: string]: UISchemaComponent<T> }) &
+  { [UISchema.Options.Key]?: UISchema.Options };
 
 type UISchema = UISchemaComponent;
 
 namespace UISchema {
-  export type CollapseOption = "all" | "none" | "unrequired" | undefined;
+  export type Options = {
+    collapse?: UISchema.Options.Collapse
+    ignoreEmpty?: boolean
+  };
 
-  export const Key = Symbol("svelte-jsonschema-form UI schema context key");
-  export const OptionsKey = ":ui:";
+  export namespace Options {
+    export const Key = ":ui:";
+    export const ContextKey = Symbol("svelte-jsonschema-form UI schema context key");
+    export type Collapse = "all" | "none" | "unrequired" | undefined;
 
-  export function get() {
-    return getContext<Readable<UISchema>>(Key);
+    export function get() {
+      return getContext<Readable<Options>>(ContextKey);
+    }
+
+    export function store(options: Options) {
+      const store = writable(options);
+      return setContext(ContextKey, store);
+    }
   }
 
-  export function store(uischema: UISchema) {
-    const store = writable(uischema);
-    return setContext(Key, store);
-  }
 
-  export function shouldCollapse(schema: JSONSchema7, setting: CollapseOption, fallback: boolean) {
+  export function shouldCollapse(schema: JSONSchema7, setting: Options.Collapse, fallback: boolean) {
     switch (setting) {
       case "all":
         return true;

--- a/src/lib/UISchema.ts
+++ b/src/lib/UISchema.ts
@@ -3,12 +3,22 @@ import { getContext, setContext } from 'svelte';
 import { writable, type Readable } from "svelte/store";
 import { hasRequired } from "./utilities";
 
-type UISchema = {
-  collapse?: "all" | "none" | "unrequired"
-};
+type UISchemaComponent<T extends string = string> =
+  (T extends typeof UISchema.OptionsKey ? never : { [key: string]: UISchemaComponent<T> }) &
+  {
+    [UISchema.OptionsKey]?: {
+      collapse?: UISchema.CollapseOption
+      ignoreEmpty?: boolean
+    }
+  };
+
+type UISchema = UISchemaComponent;
 
 namespace UISchema {
+  export type CollapseOption = "all" | "none" | "unrequired" | undefined;
+
   export const Key = Symbol("svelte-jsonschema-form UI schema context key");
+  export const OptionsKey = ":ui:";
 
   export function get() {
     return getContext<Readable<UISchema>>(Key);
@@ -19,7 +29,7 @@ namespace UISchema {
     return setContext(Key, store);
   }
 
-  export function shouldCollapse(schema: JSONSchema7, setting: UISchema['collapse'], fallback: boolean) {
+  export function shouldCollapse(schema: JSONSchema7, setting: CollapseOption, fallback: boolean) {
     switch (setting) {
       case "all":
         return true;

--- a/src/lib/UISchema.ts
+++ b/src/lib/UISchema.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema7 } from "json-schema";
 import { getContext, setContext } from 'svelte';
-import { writable, type Readable } from "svelte/store";
+import { writable, type Readable, derived } from "svelte/store";
 import { hasRequired } from "./utilities";
 
 type UISchemaComponent<T extends string = string> =
@@ -20,16 +20,18 @@ namespace UISchema {
     export const ContextKey = Symbol("svelte-jsonschema-form UI schema context key");
     export type Collapse = "all" | "none" | "unrequired" | undefined;
 
-    export function get() {
-      return getContext<Readable<Options>>(ContextKey);
-    }
-
-    export function store(options: Options) {
-      const store = writable(options);
-      return setContext(ContextKey, store);
+    export function get(uischema?: UISchema) {
+      const rootOpts = getContext<Readable<Options>>(ContextKey);
+      const opts = uischema?.[Key];
+      return derived(rootOpts, $rootOpts => ({ ...$rootOpts, ...opts }));
     }
   }
 
+  export function store(uischema: UISchema) {
+    const options = uischema?.[Options.Key] ?? {};
+    const store = writable(options);
+    return setContext(Options.ContextKey, store);
+  }
 
   export function shouldCollapse(schema: JSONSchema7, setting: Options.Collapse, fallback: boolean) {
     switch (setting) {

--- a/src/lib/controls/AnyOfControl.svelte
+++ b/src/lib/controls/AnyOfControl.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
+  import type UISchema from "$lib/UISchema";
   import deepEquals from "fast-deep-equal";
   import { tick } from 'svelte';
   import { isObjectSchema, omit } from "$lib/utilities";
@@ -10,6 +11,7 @@
 
   export let type: JSONSchema7['type'] = undefined;
   export let data: any;
+  export let uischema: UISchema = {};
   export let anyOf: JSONSchema7Definition[] = [];
 
   const keys = new WeakMap<JSONSchema7, string>();
@@ -84,9 +86,9 @@
   <Content class="jsonschema-form-controls">
     {#if selected != null}
       {#if isObjectSchema(typeSchema)}
-        <ObjectProps {...selected} bind:data />
+        <ObjectProps {...selected} bind:data {uischema} />
       {:else}
-        <Control schema={selected} bind:data force />
+        <Control schema={selected} bind:data {uischema} force />
       {/if}
     {/if}
   </Content>

--- a/src/lib/controls/ArrayControl.svelte
+++ b/src/lib/controls/ArrayControl.svelte
@@ -45,7 +45,7 @@
   $: updateEnabled(data, hasRequired);
   $: updateData(enabled);
   $: updateOpen(enabled);
-  $: updateOpen($uischema.collapse);
+  $: updateOpen($uischema[UISchema.OptionsKey]?.collapse);
 
   function getKey(index: number) {
     const value = data![index];
@@ -105,8 +105,8 @@
   }
 
   function updateOpen(enabled: boolean): void;
-  function updateOpen(collapse: UISchema['collapse']): void;
-  function updateOpen(arg: boolean | UISchema['collapse']) {
+  function updateOpen(collapse: UISchema.CollapseOption): void;
+  function updateOpen(arg: boolean | UISchema.CollapseOption) {
     open = hasItems || (isBoolean(arg) ? arg : !UISchema.shouldCollapse($$props, arg, open));
   }
 

--- a/src/lib/controls/ArrayControl.svelte
+++ b/src/lib/controls/ArrayControl.svelte
@@ -30,7 +30,7 @@
   let additional: JSONSchema7 | undefined = undefined;
   let canAddItem = false;
   let enabled = true;
-  const uischema = UISchema.get();
+  const uiOptions = UISchema.Options.get();
 
   $: hasItems = (data?.length ?? 0) > 0;
   $: {
@@ -45,7 +45,7 @@
   $: updateEnabled(data, hasRequired);
   $: updateData(enabled);
   $: updateOpen(enabled);
-  $: updateOpen($uischema[UISchema.OptionsKey]?.collapse);
+  $: updateOpen($uiOptions.collapse);
 
   function getKey(index: number) {
     const value = data![index];
@@ -105,8 +105,8 @@
   }
 
   function updateOpen(enabled: boolean): void;
-  function updateOpen(collapse: UISchema.CollapseOption): void;
-  function updateOpen(arg: boolean | UISchema.CollapseOption) {
+  function updateOpen(collapse: UISchema.Options.Collapse): void;
+  function updateOpen(arg: boolean | UISchema.Options.Collapse) {
     open = hasItems || (isBoolean(arg) ? arg : !UISchema.shouldCollapse($$props, arg, open));
   }
 

--- a/src/lib/controls/ArrayControl.svelte
+++ b/src/lib/controls/ArrayControl.svelte
@@ -160,7 +160,12 @@
           {#each data as value, index (getKey(index))}
             <li>
               <div class="jsonschema-form-controls">
-                <Control schema={getItem(index)} bind:data={value} force />
+                <Control
+                  schema={getItem(index)}
+                  bind:data={value}
+                  uischema={uischema?.["items"]}
+                  force
+                />
               </div>
               <div class="control-array-item-actions">
                 <IconButton

--- a/src/lib/controls/ArrayControl.svelte
+++ b/src/lib/controls/ArrayControl.svelte
@@ -7,6 +7,7 @@
   import Control from "../Control.svelte";
 
   export let data: any[] | undefined = undefined;
+  export let uischema: UISchema = {};
   export let title: string | undefined = undefined;
   export let description: string | null = null;
 
@@ -30,8 +31,8 @@
   let additional: JSONSchema7 | undefined = undefined;
   let canAddItem = false;
   let enabled = true;
-  const uiOptions = UISchema.Options.get();
 
+  $: uiOptions = UISchema.Options.get(uischema);
   $: hasItems = (data?.length ?? 0) > 0;
   $: {
     const itemsIsArray = Array.isArray(items);

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -25,11 +25,11 @@
   $: updateEnabled(data, hasRequired);
   $: updateData(enabled);
   $: updateOpen(enabled);
-  $: updateOpen($uischema.collapse);
+  $: updateOpen($uischema[UISchema.OptionsKey]?.collapse);
 
   function updateOpen(enabled: boolean): void;
-  function updateOpen(collapse: UISchema['collapse']): void;
-  function updateOpen(arg: boolean | UISchema['collapse']) {
+  function updateOpen(collapse: UISchema.CollapseOption): void;
+  function updateOpen(arg: boolean | UISchema.CollapseOption) {
     open = hasProps && (isBoolean(arg) ? arg : !UISchema.shouldCollapse($$props, arg, open));
   }
 

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -23,9 +23,9 @@
   $: justAnyOf = (title == null) && (properties == null) && (anyOf != null);
   $: hasProps = !!Object.keys(properties ?? {}).length || !!Object.keys(anyOf ?? {}).length;
   $: hasRequired = checkRequired({ properties, required, anyOf });
-  $: updateData(enabled);
   $: ignoreEmpty = $uiOptions.ignoreEmpty ?? false;
   $: updateEnabled(data, hasRequired, ignoreEmpty);
+  $: updateData(enabled);
   $: updateOpen(enabled);
   $: updateOpen($uiOptions.collapse);
 

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -14,6 +14,7 @@
   export let properties: { [prop: string]: any } | undefined = undefined;
   export let required: string[] = [];
   export let anyOf: JSONSchema7Definition[] | undefined = undefined;
+  export let isRequired: boolean | undefined = undefined;
 
   let open = true;
   let hasProps = false;
@@ -22,7 +23,7 @@
   $: uiOptions = UISchema.Options.get(uischema);
   $: justAnyOf = (title == null) && (properties == null) && (anyOf != null);
   $: hasProps = !!Object.keys(properties ?? {}).length || !!Object.keys(anyOf ?? {}).length;
-  $: hasRequired = checkRequired({ properties, required, anyOf });
+  $: hasRequired = isRequired || checkRequired({ properties, required, anyOf });
   $: ignoreEmpty = $uiOptions.ignoreEmpty ?? false;
   $: updateEnabled(data, hasRequired, ignoreEmpty);
   $: updateData(enabled);

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -23,8 +23,9 @@
   $: justAnyOf = (title == null) && (properties == null) && (anyOf != null);
   $: hasProps = !!Object.keys(properties ?? {}).length || !!Object.keys(anyOf ?? {}).length;
   $: hasRequired = checkRequired({ properties, required, anyOf });
-  $: updateEnabled(data, hasRequired);
   $: updateData(enabled);
+  $: ignoreEmpty = $uiOptions.ignoreEmpty ?? false;
+  $: updateEnabled(data, hasRequired, ignoreEmpty);
   $: updateOpen(enabled);
   $: updateOpen($uiOptions.collapse);
 
@@ -34,8 +35,8 @@
     open = hasProps && (isBoolean(arg) ? arg : !UISchema.shouldCollapse($$props, arg, open));
   }
 
-  function updateEnabled(data: any, hasRequired: boolean) {
-    const shouldEnable = hasRequired || !!data;
+  function updateEnabled(data: any, hasRequired: boolean, ignoreEmpty: boolean) {
+    const shouldEnable = hasRequired || ignoreEmpty || !!data;
     if (shouldEnable != enabled) {
       enabled = shouldEnable;
     }
@@ -57,9 +58,15 @@
   <AnyOfControl {anyOf} type={'object'} bind:data {uischema} />
 {:else}
   <Accordion class="jsonschema-form-control control-object">
-    <Panel bind:open variant="unelevated" disabled={!enabled} class={hasRequired ? "has-required" : undefined} nonInteractive={!hasProps}>
+    <Panel
+      bind:open
+      variant="unelevated"
+      disabled={!enabled}
+      class={(hasRequired || ignoreEmpty) ? "no-disable" : undefined}
+      nonInteractive={!hasProps}
+    >
       <Header>
-        {#if !hasRequired}
+        {#if !hasRequired && !ignoreEmpty}
           <IconButton type="button" toggle bind:pressed={enabled} size="button" on:click={stop}>
             <Icon class="material-icons" on>check_box</Icon>
             <Icon class="material-icons">check_box_outline_blank</Icon>

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -13,11 +13,12 @@
   export let properties: { [prop: string]: any } | undefined = undefined;
   export let required: string[] = [];
   export let anyOf: JSONSchema7Definition[] | undefined = undefined;
+  // export let uischema: UISchema = {};
 
   let open = true;
   let hasProps = false;
   let enabled = true;
-  const uischema = UISchema.get();
+  const uiOptions = UISchema.Options.get();
 
   $: justAnyOf = (title == null) && (properties == null) && (anyOf != null);
   $: hasProps = !!Object.keys(properties ?? {}).length || !!Object.keys(anyOf ?? {}).length;
@@ -25,11 +26,11 @@
   $: updateEnabled(data, hasRequired);
   $: updateData(enabled);
   $: updateOpen(enabled);
-  $: updateOpen($uischema[UISchema.OptionsKey]?.collapse);
+  $: updateOpen($uiOptions.collapse);
 
   function updateOpen(enabled: boolean): void;
-  function updateOpen(collapse: UISchema.CollapseOption): void;
-  function updateOpen(arg: boolean | UISchema.CollapseOption) {
+  function updateOpen(collapse: UISchema.Options.Collapse): void;
+  function updateOpen(arg: boolean | UISchema.Options.Collapse) {
     open = hasProps && (isBoolean(arg) ? arg : !UISchema.shouldCollapse($$props, arg, open));
   }
 

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -44,8 +44,9 @@
 
   function updateData(enabled: boolean) {
     const hasData = (data != null);
-    if (hasData != enabled) {
-      data = enabled ? {} : undefined;
+    const shouldHaveData = enabled && !ignoreEmpty;
+    if (hasData != shouldHaveData) {
+      data = shouldHaveData ? {} : undefined;
     }
   }
 

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -8,18 +8,18 @@
   import ObjectProps from "./ObjectProps.svelte";
 
   export let data: { [prop: string]: any } | undefined = undefined;
+  export let uischema: UISchema = {};
   export let title: string | undefined = undefined;
   export let description: string | undefined = undefined;
   export let properties: { [prop: string]: any } | undefined = undefined;
   export let required: string[] = [];
   export let anyOf: JSONSchema7Definition[] | undefined = undefined;
-  // export let uischema: UISchema = {};
 
   let open = true;
   let hasProps = false;
   let enabled = true;
-  const uiOptions = UISchema.Options.get();
 
+  $: uiOptions = UISchema.Options.get(uischema);
   $: justAnyOf = (title == null) && (properties == null) && (anyOf != null);
   $: hasProps = !!Object.keys(properties ?? {}).length || !!Object.keys(anyOf ?? {}).length;
   $: hasRequired = checkRequired({ properties, required, anyOf });

--- a/src/lib/controls/ObjectControl.svelte
+++ b/src/lib/controls/ObjectControl.svelte
@@ -54,7 +54,7 @@
 </script>
 
 {#if justAnyOf}
-  <AnyOfControl {anyOf} type={'object'} bind:data />
+  <AnyOfControl {anyOf} type={'object'} bind:data {uischema} />
 {:else}
   <Accordion class="jsonschema-form-control control-object">
     <Panel bind:open variant="unelevated" disabled={!enabled} class={hasRequired ? "has-required" : undefined} nonInteractive={!hasProps}>
@@ -77,7 +77,7 @@
         </svelte:fragment>
       </Header>
       <Content class="jsonschema-form-controls">
-        <ObjectProps {properties} {required} {anyOf} bind:data />
+        <ObjectProps {properties} {required} {anyOf} bind:data {uischema} />
       </Content>
     </Panel>
   </Accordion>

--- a/src/lib/controls/ObjectProps.svelte
+++ b/src/lib/controls/ObjectProps.svelte
@@ -25,7 +25,7 @@
 
 {#if !!data}
   {#each items as { name, schema, uischema } (name)}
-    <Control {schema} bind:data={values[name]} {uischema} />
+    <Control {schema} bind:data={data[name]} {uischema} />
   {/each}
 {/if}
 {#if (anyOf != null)}

--- a/src/lib/controls/ObjectProps.svelte
+++ b/src/lib/controls/ObjectProps.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { JSONSchema7Definition } from "json-schema";
+  import type UISchema from "$lib/UISchema";
   import Control from "../Control.svelte";
   import AnyOfControl from "./AnyOfControl.svelte";
 
   export let data: { [prop: string]: any } | undefined;
+  export let uischema: UISchema = {};
   export let properties: { [prop: string]: any } | undefined = undefined;
   export let required: string[] = [];
   export let anyOf: JSONSchema7Definition[] | undefined = undefined;
@@ -12,9 +14,9 @@
 {#if (properties != null) && (data != null)}
   {#each Object.entries(properties) as [name, props] (name)}
     {@const schema = {title: name, ...props, isRequired: required.includes(name)}}
-    <Control {schema} bind:data={data[name]} />
+    <Control {schema} bind:data={data[name]} uischema={uischema[name]} />
   {/each}
 {/if}
 {#if (anyOf != null)}
-  <AnyOfControl {anyOf} type={'object'} bind:data />
+  <AnyOfControl {anyOf} type={'object'} bind:data {uischema} />
 {/if}

--- a/src/lib/controls/ObjectProps.svelte
+++ b/src/lib/controls/ObjectProps.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
-  import type UISchema from "$lib/UISchema";
+  import UISchema from "$lib/UISchema";
   import Control from "../Control.svelte";
   import AnyOfControl from "./AnyOfControl.svelte";
+  import { isEmpty } from "$lib/utilities";
 
   export let data: { [prop: string]: any } | undefined;
   export let uischema: UISchema = {};
@@ -11,8 +12,13 @@
   export let anyOf: JSONSchema7Definition[] | undefined = undefined;
 
   let items = [] as { name: string, schema: JSONSchema7, uischema: UISchema }[];
+  let values: { [prop: string]: any } | undefined;
 
+  $: uiOptions = UISchema.Options.get(uischema);
+  $: ignoreEmpty = $uiOptions.ignoreEmpty ?? false;
   $: updateItems(properties, uischema);
+  $: updateValues(data, ignoreEmpty);
+  $: updateData(values);
 
   function updateItems(properties: { [prop: string]: any } | undefined, uischema: UISchema) {
     items = (properties == null) ? [] :
@@ -21,11 +27,29 @@
         return { name, schema, uischema: uischema?.[name] };
       });
   }
+
+  function updateValues(data: { [prop: string]: any } | undefined, ignoreEmpty: boolean) {
+    if (ignoreEmpty && (data == null) && ((values == null) || !isEmpty(values))) {
+      values = {};
+    }
+    else {
+      values = data;
+    }
+  }
+
+  function updateData(values: { [prop: string]: any } | undefined) {
+    if (ignoreEmpty && (values != null) && isEmpty(values) && (data != null)) {
+      data = undefined;
+    }
+    else {
+      data = values;
+    }
+  }
 </script>
 
-{#if !!data}
+{#if !!values}
   {#each items as { name, schema, uischema } (name)}
-    <Control {schema} bind:data={data[name]} {uischema} />
+    <Control {schema} bind:data={values[name]} {uischema} />
   {/each}
 {/if}
 {#if (anyOf != null)}

--- a/src/lib/controls/ObjectProps.svelte
+++ b/src/lib/controls/ObjectProps.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { JSONSchema7Definition } from "json-schema";
+  import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
   import type UISchema from "$lib/UISchema";
   import Control from "../Control.svelte";
   import AnyOfControl from "./AnyOfControl.svelte";
@@ -9,12 +9,23 @@
   export let properties: { [prop: string]: any } | undefined = undefined;
   export let required: string[] = [];
   export let anyOf: JSONSchema7Definition[] | undefined = undefined;
+
+  let items = [] as { name: string, schema: JSONSchema7, uischema: UISchema }[];
+
+  $: updateItems(properties, uischema);
+
+  function updateItems(properties: { [prop: string]: any } | undefined, uischema: UISchema) {
+    items = (properties == null) ? [] :
+      Object.entries(properties).map(([name, props]) => {
+        const schema = {title: name, ...props, isRequired: required.includes(name)};
+        return { name, schema, uischema: uischema?.[name] };
+      });
+  }
 </script>
 
-{#if (properties != null) && (data != null)}
-  {#each Object.entries(properties) as [name, props] (name)}
-    {@const schema = {title: name, ...props, isRequired: required.includes(name)}}
-    <Control {schema} bind:data={data[name]} uischema={uischema[name]} />
+{#if !!data}
+  {#each items as { name, schema, uischema } (name)}
+    <Control {schema} bind:data={values[name]} {uischema} />
   {/each}
 {/if}
 {#if (anyOf != null)}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,4 @@
 export { default as default } from "./SchemaForm.svelte";
 export type { JSONSchema7 } from "json-schema";
 export type { default as ValidationError } from "./ValidationError";
+export type { default as UISchema } from "./UISchema";

--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -44,3 +44,13 @@ export function omit<T extends Record<any, any>, K extends keyof T>(obj: T, keys
       return acc;
     }, {} as Omit<T, K>)
 }
+
+export function isDefined<T>(value: T | undefined): value is T {
+  return (value != null) || (value === null);
+}
+
+export function isEmpty(obj: { [key: string]: any }) {
+  return Object.entries(obj)
+    .filter(([_, val]) => isDefined(val))
+    .length === 0;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,9 +14,10 @@
 
   let active = schemas[0];
   let schema: TestSchema["schema"];
+  let uischema: UISchema;
   let data: TestSchema["data"];
-  const uischema = { ":ui:": { collapse: "unrequired" }} as const;
   let schemaString = "";
+  let uischemaString = "";
   let dataString = "";
   let validationError: ValidationError | null = null;
 
@@ -25,12 +26,18 @@
 
   $: updateActive(active);
   $: setSchemaString(schema);
+  $: setUISchemaString(uischema);
   $: setDataString(data);
   $: if (validationError != null) errorSnackbar.open();
 
   async function setSchemaString(schema: TestSchema["schema"]) {
     await tick();
     schemaString = JSON.stringify(schema, null, 2);
+  }
+
+  async function setUISchemaString(uischema: UISchema) {
+    await tick();
+    uischemaString = JSON.stringify(uischema, null, 2);
   }
 
   async function setDataString(data: TestSchema["data"]) {
@@ -40,12 +47,21 @@
 
   function updateActive(active: TestSchema) {
     schema = structuredClone(active.schema);
+    uischema = structuredClone(active.uischema) ?? {};
     data = structuredClone(active.data);
   }
 
   function setSchema() {
     try {
       schema = JSON.parse(schemaString);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  function setUISchema() {
+    try {
+      uischema = JSON.parse(uischemaString);
     } catch (error) {
       console.error(error);
     }
@@ -107,6 +123,13 @@
     bind:value={schemaString}
     on:change={setSchema}
     label="Schema"
+  />
+
+  <Textfield
+    textarea
+    bind:value={uischemaString}
+    on:change={setUISchema}
+    label="UI Schema"
   />
 
   <Textfield

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,10 +10,12 @@
   import SchemaForm, { type ValidationError } from "$lib";
   import schemas, { type TestSchema } from "../schemas";
 
+  import type UISchema from "$lib/UISchema";
+
   let active = schemas[0];
   let schema: TestSchema["schema"];
   let data: TestSchema["data"];
-  const uischema = { collapse: "unrequired" } as const;
+  const uischema = { ":ui:": { collapse: "unrequired" }} as const;
   let schemaString = "";
   let dataString = "";
   let validationError: ValidationError | null = null;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema7 } from "json-schema";
+import type UISchema from "$lib/UISchema";
 import simpleSchema from "../schemas/simple/schema.json";
 import simpleData from "../schemas/simple/data.json";
 import nestedSchema from "../schemas/nested/schema.json";
@@ -13,12 +14,14 @@ import anyOfSchema from "../schemas/any-of/schema.json";
 import anyOfData from "../schemas/any-of/data.json";
 import allOfSchema from "../schemas/all-of/schema.json";
 import allOfData from "../schemas/all-of/data.json";
-import taxonomySchema from "../schemas/taxonomy/schema.json"; 
+import taxonomySchema from "../schemas/taxonomy/schema.json";
+import taxonomyUISchema from "../schemas/taxonomy/uischema.json";
 import taxonomyData from "../schemas/taxonomy/data.json"; 
 
 export type TestSchema = {
   name: string;
   schema: JSONSchema7;
+  uischema?: UISchema;
   data: { [prop: string]: any };
 };
 
@@ -61,6 +64,7 @@ export default [
   {
     name: "Taxonomy",
     schema: taxonomySchema,
+    uischema: taxonomyUISchema,
     data: taxonomyData
   }
 ] as TestSchema[];

--- a/src/schemas/taxonomy/uischema.json
+++ b/src/schemas/taxonomy/uischema.json
@@ -1,0 +1,5 @@
+{
+  ":ui:": {
+    "collapse": "unrequired"
+  }
+}

--- a/src/theme/_custom.scss
+++ b/src/theme/_custom.scss
@@ -16,6 +16,7 @@ $separator-color: #707070;
       color: #{$root-header-bg};
       border-radius: 6px;
       align-items: center;
+      min-height: 36px;
 
       > .smui-accordion__header__title {
         display: inline-flex;
@@ -52,7 +53,7 @@ $separator-color: #707070;
       }
     }
 
-    &.has-required > .smui-accordion__header {
+    &.no-disable > .smui-accordion__header {
       padding-left: 18px;
     }
   }


### PR DESCRIPTION
Adds support for an "ignoreEmpty" ui option for "object" and "array" types. This will prevent adding these properties to the data if they are "empty". This also introduces a ":ui:" key to the ui schema for the actual ui options to allow the nesting of these options for individual sub-properties.

 Setting the option would look like this:

```json
{
	":ui:": {
		"collapse": "unrequired"
	},
	"rootObject": {
		"objectProperty": {
			":ui:": {
				"ignoreEmpty": true
			}
		}
	}
}
```

Note how this also changes the existing behavior of setting "global" ui options (such as the "collapse" option).

resolves #7