### PR TITLE
Add automated tests using playwright

### DIFF
--- a/tests/anyOf.ts
+++ b/tests/anyOf.ts
@@ -1,0 +1,24 @@
+import { test } from "@playwright/test";
+
+test.describe("anyOf", function () {
+  test("hide (empty) field header", async ({ _page }) => {
+    // TODO: create an enum
+    // TODO: select an option
+    // TODO: ensure the option doesn't show again below the header
+    test.fixme();
+  });
+
+  test("show nested field options", async ({ _page }) => {
+    // TODO: create an enum
+    // TODO: select an option (with nested fields)
+    // TODO: ensure the fields are shown
+    test.fixme();
+  });
+
+  test("set nested field options", async ({ _page }) => {
+    // TODO: create an enum
+    // TODO: select an option (with nested fields)
+    // TODO: ensure the fields can be set
+    test.fixme();
+  });
+});

--- a/tests/array.ts
+++ b/tests/array.ts
@@ -1,0 +1,15 @@
+import { test } from "@playwright/test";
+
+test.describe("array", function () {
+  test("add integer to array", async ({ _page }) => {
+    test.fixme();
+  });
+
+  test("add compound field to array", async ({ _page }) => {
+    test.fixme();
+  });
+
+  test("remove item from array", async ({ _page }) => {
+    test.fixme();
+  });
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,10 @@
-import { expect, test } from '@playwright/test';
+import { test } from "@playwright/test";
 
-test('index page has expected h1', async ({ page }) => {
-	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+test.describe("required options", function () {
+  test("dont expand required field in optional parent", async ({ _page }) => {
+    // TODO: create an enum
+    // TODO: select an option (with nested fields)
+    // TODO: ensure the fields can be set
+    test.fixme();
+  });
 });

--- a/tests/uiSchema.ts
+++ b/tests/uiSchema.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+
+test.describe("uiSchema", function () {
+  test.describe("ignoreEmpty", function () {
+    test("don't show a checkbox", async ({ _page }) => {
+      test.fixme();
+    });
+
+    test("don't include the property on download", async ({ _page }) => {
+      test.fixme();
+    });
+  });
+});


### PR DESCRIPTION
I added some stubbed out tests to be added. Basically, it would be great to have some tests for each type of control. I imagine the playwright tests could 
1. simply view the same playground that is hosted on GH pages
2. set the schema and uiSchema then run the test (probably should use some utilities to avoid too much code dupe there)
3. check the output in the third window (or download and check in the `ignoreEmpty` case)

@romancow - Can you take it from here?
