### PR TITLE
Bundle patched dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,6 @@
 		"json-schema-merge-allof": "^0.8.1",
 		"patch-package": "^7.0.2",
 		"svelte-portal": "^2.2.0"
-	}
+	},
+	"bundleDependencies": ["@json-schema-tools/dereferencer", "@smui/select", "svelte-portal"]
 }


### PR DESCRIPTION
Adds patched dependencies to package's "bundleDependencies", so they will be in own `node_modules` folder and will be patched. 