### PR TITLE
Dispatch schema compile errors

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 // Reexport your entry components here
 export { default as default } from "./SchemaForm.svelte";
 export type { JSONSchema7 } from "json-schema";
-export type { default as ValidationError } from "./ValidationError";
+export { default as ValidationError } from "./ValidationError";
 export type { default as UISchema } from "./UISchema";


### PR DESCRIPTION
This adds an "error" event dispatcher to the `SchemaForm` component to dispatch both schema compile and dereferencing errors.